### PR TITLE
2 teste de unidade para o método PropertyService::getRoomArea

### DIFF
--- a/src/main/java/br/com/desafio/teste/g8/desafioteste/desafioteste/controller/AppController.java
+++ b/src/main/java/br/com/desafio/teste/g8/desafioteste/desafioteste/controller/AppController.java
@@ -1,8 +1,14 @@
 package br.com.desafio.teste.g8.desafioteste.desafioteste.controller;
 
+import br.com.desafio.teste.g8.desafioteste.desafioteste.entity.Property;
 import br.com.desafio.teste.g8.desafioteste.desafioteste.test.unit.PropertyService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
 
 @RestController
 public class AppController {
@@ -12,6 +18,18 @@ public class AppController {
     @Autowired
     public AppController(PropertyService propertyService) {
         this.propertyService = propertyService;
+    }
+
+    @PostMapping("/properties")
+    public ResponseEntity registerProperty(@RequestBody Property property) throws URISyntaxException {
+        return ResponseEntity
+                .created(new URI("/properties"))
+                .body(this.propertyService.createProperty(property));
+    }
+
+    @GetMapping("/area/{roomName}")
+    public ResponseEntity<Map<String, Double>> getRoomArea(@PathVariable("roomName") String roomName) {
+        return ResponseEntity.ok(this.propertyService.getRoomArea(roomName));
     }
 }
     

--- a/src/test/java/br/com/desafio/teste/g8/desafioteste/desafioteste/test/unit/PropertyServiceTest.java
+++ b/src/test/java/br/com/desafio/teste/g8/desafioteste/desafioteste/test/unit/PropertyServiceTest.java
@@ -14,13 +14,13 @@ import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class PropertyServiceTest {
 
-    private PropertyService propertyService;
-
     @Mock
     private PropertyRepository propertyRepositoryMock;
+    private PropertyService propertyService;
     private Property fakeProperty;
 
     public Property createFakeProperty() {
@@ -104,7 +104,11 @@ public class PropertyServiceTest {
 
         assertTrue(nullExp.getMessage().contains(""));
     }
-  
+
+    /**
+     * @author Ronaldd Pinho
+     * @description Testa se retorna o maior cômodo dada uma propriedade.
+     */
     @Test
     public void deveRetornarOMaiorComodoDaPropriedade() {
         Property mockedProperty = this.createFakeProperty();
@@ -116,5 +120,41 @@ public class PropertyServiceTest {
         Room result = this.propertyService.getBiggestRoom(mockedProperty.getName());
 
         assertEquals(result, mockedBiggestRoom);
+    }
+
+    /**
+     * @author Ronaldd Pinho
+     * @description Testa se de fato o total de metros quadrados por cômodo está correto.
+     */
+    @Test
+    public void deveRetornarAsAreasDeCadaComodoDeUmaPropriedade() {
+        fakeProperty = createFakeProperty();
+        when(this.propertyRepositoryMock.findByName(anyString()))
+                .thenReturn(fakeProperty);
+
+        Map<String, Double> areas = this.propertyService.getRoomArea(fakeProperty.getName());
+
+        assertTrue(areas.get("sala") == 50.0 &&
+                areas.get("quarto 1") == 16.0 &&
+                areas.get("cozinha") == 9.0);
+    }
+
+    /**
+     * @author Ronaldd Pinho
+     * @description Testa se o método getRoomArea do serviço lança um NullPointerException com mensagem nula quando
+     * o método findByName do repository retornar null por nõ encontrar o registro no repositório.
+     */
+    @Test
+    public void deveLancarExcecaoQuandoOFindByNameRetornaNullNoGetRoomArea() {
+        fakeProperty = this.createFakeProperty();
+        when(this.propertyRepositoryMock.findByName(anyString()))
+                .thenReturn(null);
+
+        NullPointerException exc = assertThrows(
+                NullPointerException.class,
+                () -> this.propertyService.getRoomArea(anyString()));
+
+        assertEquals(null, exc.getMessage());
+//        assertNull(exc.getMessage());
     }
 }


### PR DESCRIPTION
Foram adicionados 2 endpoint no controller:

1. `POST /properties`: Cadastra uma nova propriedade;
2. `GET /area/:roomArea`: Retorna a listagem de áreas para cada quarto de uma propriedade buscada no repositório por nome.

Foram implementados 2 teste de unidade para o método PropertyService::getRoomArea:

1. Testa o retorno do método;
2. Testa se o método laná um `NullPointerException` quando o `repository.findByName()` retorna `null`.