### PR TITLE
Corrige erro de sintaxe na classe DistrictDTO

### DIFF
--- a/src/main/java/br/com/desafio/teste/g8/desafioteste/desafioteste/dto/DistrictDTO.java
+++ b/src/main/java/br/com/desafio/teste/g8/desafioteste/desafioteste/dto/DistrictDTO.java
@@ -49,7 +49,7 @@ public class DistrictDTO {
     public DistrictDTO toDistrictDTO (District district){
         return DistrictDTO.builder().
                 name(district.getName()).pricePerM2(district.getPricePerM2()).
-                build());
+                build();
     }
 
     /**


### PR DESCRIPTION
Erro: tinha um ")"a mais.